### PR TITLE
feat(QM-5): load a true/false question into the question bank and display in tree

### DIFF
--- a/src/assets/icons/icon-truefalse.svg
+++ b/src/assets/icons/icon-truefalse.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="isolation:isolate" width="16" height="16" preserveAspectRatio="xMinYMid meet"><defs><clipPath id="a"><path d="M0 0h16v16H0z"/></clipPath></defs><g clip-path="url(#a)"><path d="M10 8a2 2 0 1 1 4.001.001A2 2 0 0 1 10 8zM2 8a2 2 0 1 1 4.001.001A2 2 0 0 1 2 8z"/></g></svg>

--- a/src/components/QuestionBankSection/CustomNode.jsx
+++ b/src/components/QuestionBankSection/CustomNode.jsx
@@ -30,7 +30,7 @@ export const CustomNode = (props) => {
         )}
       </div>
       <div>
-        <TypeIcon droppable={droppable} fileType={data?.fileType} />
+        <TypeIcon droppable={droppable} questionType={data?.questionType} />
       </div>
       <div className={styles.labelGridItem}>
         <Typography variant="body2">{props.node.text}</Typography>

--- a/src/components/QuestionBankSection/QBTree.js
+++ b/src/components/QuestionBankSection/QBTree.js
@@ -105,7 +105,7 @@ const QBTree = (props) => {
                 text: questionbank[i].name,
                 parent: getParentCategoryKey(questionbank[i], questionbank),
                 droppable: questionbank[i].type === 'category' ? true : false,
-                data: { fileType: questionbank[i].type }
+                data: { questionType: questionbank[i].type }
             }
             myTreeData.push(data);
         }

--- a/src/components/QuestionBankSection/TypeIcon.jsx
+++ b/src/components/QuestionBankSection/TypeIcon.jsx
@@ -1,21 +1,25 @@
 import React from "react";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import FolderIcon from "@mui/icons-material/Folder";
 import ImageIcon from "@mui/icons-material/Image";
 import ListAltIcon from "@mui/icons-material/ListAlt";
 import DescriptionIcon from "@mui/icons-material/Description";
 import description from "../../assets/icons/icon-description.svg";
 import essay from "../../assets/icons/icon-essay.svg";
+import truefalse from "../../assets/icons/icon-truefalse.svg";
 
 export const TypeIcon = (props) => {
   if (props.droppable) {
-    return <FolderIcon />;
+    return <FolderOpenIcon />;
   }
 
-  switch (props.fileType) {
+  switch (props.questionType) {
     case "description":
       return <img src={description} alt="Description" />;
     case "essay":
       return <img src={essay} alt="Essay" />;
+      case "truefalse":
+        return <img src={truefalse} alt="True-False" />;
     case "image":
       return <ImageIcon />;
     case "csv":

--- a/src/components/QuestionBankSection/UtilityFunctions/loadXMLFile.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/loadXMLFile.js
@@ -51,8 +51,7 @@ export function loadXMLFile(questionbank, myFile) {
                 }
             case "essay":
                 {
-                    //any other fields needed for this type?
-                    console.log("question.type is 'essay'");
+                    //console.log("question.type is 'essay'");
                     question.name = xmlQList[i].getElementsByTagName('text')[0].firstChild.nodeValue;
                     question.question_text = xmlQList[i].getElementsByTagName('questiontext')[0].getElementsByTagName('text')[0].childNodes[0].nodeValue;
                     question.default_grade = xmlQList[i].getElementsByTagName('defaultgrade')[0].childNodes[0].nodeValue;
@@ -60,6 +59,55 @@ export function loadXMLFile(questionbank, myFile) {
                     questionbank.push(question);	//store the imported question in the database
                     break;
                 }
+            case "truefalse":
+                {
+                    console.log("question.type is 'truefalse'");
+                    question.name = xmlQList[i].getElementsByTagName('text')[0].firstChild.nodeValue;
+                    question.question_text = xmlQList[i].getElementsByTagName('questiontext')[0].getElementsByTagName('text')[0].childNodes[0].nodeValue;
+
+                    if (xmlQList[i].getElementsByTagName('defaultgrade')[0] && xmlQList[i].getElementsByTagName('defaultgrade')[0].childNodes[0]) {
+                        question.default_grade = xmlQList[i].getElementsByTagName('defaultgrade')[0].childNodes[0].nodeValue;
+                    }
+                    else {
+                        //if the defaultgrade is empty, make it 1                    {
+                        question.default_grade = 1;
+                    };
+
+                    if (xmlQList[i].getElementsByTagName('penalty')[0] && xmlQList[i].getElementsByTagName('penalty')[0].childNodes[0]) {
+                        question.penalty = xmlQList[i].getElementsByTagName('penalty')[0].childNodes[0].nodeValue;
+                    }
+                    else {
+                        //if the penalty is empty, make it 1
+                        question.penalty = 1;
+                    };
+
+                    var choices = xmlQList[i].getElementsByTagName('answer');
+
+                    for (var choice_nr = 0; choice_nr < choices.length; choice_nr++) {
+                        if (choices[choice_nr].getElementsByTagName('text')[0] && choices[choice_nr].getElementsByTagName('text')[0].childNodes[0])
+                            if (choices[choice_nr].getElementsByTagName('text')[0].childNodes[0].nodeValue == "") {
+                                //if the choice contains no text, we won't import it
+                                continue;
+                            }
+                            else {
+                                question.choices.push(choices[choice_nr].getElementsByTagName('text')[0].childNodes[0].nodeValue);
+                            };
+
+                        if (choices[choice_nr].getAttribute('fraction')) {
+                            question.value.push(choices[choice_nr].getAttribute('fraction'));
+                        }
+                        else {
+                            question.value.push(0);
+                        };
+
+                        if (choices[choice_nr].getElementsByTagName('feedback')[0] && choices[choice_nr].getElementsByTagName('feedback')[0].childNodes[0]) {
+                            question.feedback.push(choices[choice_nr].getElementsByTagName('feedback')[0].childNodes[0].nodeValue);
+                        };
+                    }
+                    questionbank.push(question);	//store the imported question in the database		
+                    break;
+                }
+
             default: {
                 break;
             }


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/jira/software/projects/QM/boards/34?selectedIssue=QM-5
## Context:
Load a true/false question from a Moodle file into the question bank and display it.
## Changes
- updated loadXMLfile.js to add a case for the "truefalse" question type
- updated TypeIcon to use the truefalse Moodle icon

## Before and After UI (Required for UI-impacting PRs)
Verified that everything is working with a file that has a description as well as essay and true/false questions. The last two are in their own sub-categories.

![image](https://user-images.githubusercontent.com/57333167/166077482-ec131363-5895-43be-9f44-5efd1cd0511d.png)


## Dev notes (Optional)
- Changed fileType treeData data sub property to questionType
- Updated QBTree.js to pass questionType prop instead of fileType prop to Tree component
- Updated TypeIcon.js to use questionType instead of fileType

## Linked pull requests (Optional)
- pull request link
