### PR TITLE
(feat)QM-45: View and edit essay-type questions

### DIFF
--- a/src/components/Editor/QuestionEditor.js
+++ b/src/components/Editor/QuestionEditor.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Editor } from "@tinymce/tinymce-react";
-import {Typography} from "@mui/material";
+import { Typography, TextField, Box } from "@mui/material";
 import styles from "./QuestionEditor.module.css";
 
 export default function QuestionEditor(props) {
@@ -18,9 +18,13 @@ export default function QuestionEditor(props) {
     //const questionName = props.selectedNode?.text ?? "Question";
 
     const [questionName, setQuestionName] = useState(props.selectedNode?.text ?? "Question");
+    const [defaultGrade, setDefaultGrade] = useState(props.selectedNode?.data.question.defaultGrade ?? 0.00);
+    const [penalty, setPenalty] = useState(props.selectedNode?.data.question.penalty ?? 0.00);
 
     useEffect(() => {
         setQuestionName(props.selectedNode?.text);
+        setDefaultGrade(props.selectedNode?.data.question.default_grade);
+        setPenalty(props.selectedNode?.data.question.penalty);
 
     }, [props.selectedNode]);
 
@@ -55,18 +59,23 @@ export default function QuestionEditor(props) {
         <>
             <Typography variant="h6">{questionType()}</Typography>
             {!props.selectedNode.droppable &&
-                <p>For more information on this question type, please consult 
+                <Typography variant="body1">For more information on this question type, please consult&nbsp;
                     <a href="https://docs.moodle.org/310/en/Description_question_type"
                         target="_blank">the official Moodle documentation.
                     </a>
-                </p>
+                </Typography>
             }
-            <input
+            <TextField
                 type="text"
+                id="name"
+                name="name"
+                label="Name"
+                size="small"
+                sx={{ width: 400, marginTop: 2 }}
                 value={questionName}
                 onChange={(e) => {
                     setQuestionName(e.target.value);
-                    props.onNameChange(e);                
+                    props.onFieldChange(e);
                 }} />
             {!props.selectedNode.droppable &&
                 <Editor
@@ -88,6 +97,47 @@ export default function QuestionEditor(props) {
                         content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }'
                     }}
                 />}
+            {!props.selectedNode.droppable && props.selectedNode.data.questionType !== "description" &&
+                <Box
+                    mt={1}
+                    display="flex"
+                    justifyContent="flex-start"
+                    align-items="flex-start">
+                    <TextField
+                        type="number"
+                        id="defaultGrade"
+                        name="defaultGrade"
+                        label="Default Grade"
+                        size="small"
+                        sx={{ width: 90, mx: 0.5 }}
+                        inputProps={{
+                            maxLength: 6,
+                            step: "1"
+                        }}
+                        value={parseFloat(defaultGrade).toFixed(2)}
+                        onChange={(e) => {
+                            setDefaultGrade(parseFloat(e.target.value).toFixed(2));
+                            props.onFieldChange(e);
+                        }} />
+
+                    <TextField
+                        type="number"
+                        id="penalty"
+                        name="penalty"
+                        label="Penalty"
+                        size="small"
+                        sx={{ width: 90, mx: 0.5 }}
+                        inputProps={{
+                            maxLength: 6,
+                            step: "1"
+                        }}
+                        value={parseFloat(penalty).toFixed(2)}
+                        onChange={(e) => {
+                            setPenalty(parseFloat(e.target.value).toFixed(2));
+                            props.onFieldChange(e);
+                        }} />
+                </Box>
+            }
         </>
     );
 }

--- a/src/components/QuestionBankSection/QBTree.js
+++ b/src/components/QuestionBankSection/QBTree.js
@@ -11,7 +11,7 @@ import { loadXMLFile } from "./UtilityFunctions/loadXMLFile.js";
 import { postLoadCleanUp } from "./UtilityFunctions/postLoadCleanUp";
 import { updateQuestionCategories } from "./UtilityFunctions/updateQuestionCategories.js";
 import { getDumCatKey } from "./UtilityFunctions/getDumCatKey";
-import {copyNode} from "./UtilityFunctions/helper";
+import { copyNode } from "./UtilityFunctions/helper";
 import QuestionEditor from "../Editor/QuestionEditor";
 
 const QBTree = (props) => {
@@ -25,16 +25,23 @@ const QBTree = (props) => {
         setSelectedNode(node);
     };
 
-    const handleQuestionNameChange = (e) => {
-        const newTree = treeData.map((node) => {       
+    const handleFieldChange = (e) => {
+        const newTree = treeData.map((node) => {
 
             if (node.id === selectedNode.id) {
-                console.log("value is: " + e.target.value);
-            
                 const newNode = copyNode(node);
-                newNode.text = e.target.value;
-                newNode.data.question.name = e.target.value;
-
+                switch (e.target.name) {
+                    case "name":
+                        newNode.text = e.target.value;
+                        newNode.data.question.name = e.target.value;
+                        break;
+                    case "defaultGrade":
+                        newNode.data.question.default_grade = e.target.value;
+                        break;
+                    case "penalty":
+                        newNode.data.question.penalty = e.target.value;
+                        break;
+                }
                 return newNode;
             }
             return node;
@@ -48,7 +55,7 @@ const QBTree = (props) => {
             console.log("value is: " + value);
 
             if (node.id === selectedNode.id) {
-                
+
                 let newNode = copyNode(node);
                 newNode.data.question.question_text = value;
 
@@ -134,8 +141,8 @@ const QBTree = (props) => {
                 <CssBaseline />
                 <Grid container direction="row" spacing={2}>
                     <Grid item xs={4}>
-                        <Box style={{maxHeight: 400, minHeight: 300, overflowY: 'scroll'}} className={styles.app}>
-                            
+                        <Box style={{ maxHeight: 400, minHeight: 300, overflowY: 'scroll' }} className={styles.app}>
+
                             <Tree
                                 tree={treeData}
                                 rootId={-1}
@@ -163,7 +170,7 @@ const QBTree = (props) => {
                     <Grid item xs={8}>
                         {selectedNode && <QuestionEditor
                             selectedNode={selectedNode}
-                            onNameChange={handleQuestionNameChange}
+                            onFieldChange={handleFieldChange}
                             onTextChange={handleQuestionTextChange} />}
                     </Grid>
                 </Grid>

--- a/src/components/UploadButton.js
+++ b/src/components/UploadButton.js
@@ -1,5 +1,5 @@
 import { Box, Button, Tooltip } from "@mui/material";
-import { AiOutlineUpload } from "react-icons/ai";
+import { AiOutlineUpload, AiFillFolderOpen } from "react-icons/ai";
 
 export default function UploadButton(props) {
     function changeHandler(event) {
@@ -28,7 +28,7 @@ export default function UploadButton(props) {
                         color: 'black',
                         borderColor: 'black'
                     }}>
-                    <AiOutlineUpload />
+                    <AiFillFolderOpen />
                     <input type="file" onChange={changeHandler} hidden />
                 </Button>
             </Tooltip>


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/jira/software/projects/QM/boards/34?selectedIssue=QM-45
## Context:
Add ability to view an edit essay-type questions
## Changes
- view essay questions
- edit name
- edit question text
- edit default grade
- edit penalty
- last two fields are visible for all non-droppable nodes and non-description nodes.

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://user-images.githubusercontent.com/57333167/169714812-357f808f-17a2-4404-a7c1-36a0d9b1dbb6.png)

After:
![image](https://user-images.githubusercontent.com/57333167/169714789-f55ef022-ed5b-4497-951a-e1a53a13e730.png)
## Dev notes (Optional)
- Changed upload file icon to the open file icon. 
## Linked pull requests (Optional)
- pull request link
