### PR TITLE
(feat)QM-46: edit true/false questions

### DIFF
--- a/src/components/Editor/QuestionEditor.js
+++ b/src/components/Editor/QuestionEditor.js
@@ -1,6 +1,16 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Editor } from "@tinymce/tinymce-react";
-import { Typography, TextField, Box } from "@mui/material";
+import {
+    Typography,
+    TextField,
+    Box,
+    Table,
+    TableContainer,
+    TableRow,
+    TableCell,
+    TableHead,
+    TableBody
+} from "@mui/material";
 import styles from "./QuestionEditor.module.css";
 
 export default function QuestionEditor(props) {
@@ -138,6 +148,49 @@ export default function QuestionEditor(props) {
                         }} />
                 </Box>
             }
+
+            <TableContainer>
+                <Table >
+                    <TableHead>
+                        <TableRow>
+                            <TableCell width="10%">#</TableCell>
+                            <TableCell width="40%">Choices</TableCell>
+                            <TableCell width="40%">Feedback</TableCell>
+                            <TableCell width="10%">Value</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        <TableRow>
+                            <TableCell>
+                                <TextField
+                                    variant="outlined"
+                                    placeholder="1"
+                                    size="small" />
+                            </TableCell>
+                            <TableCell>
+                                <TextField
+                                    variant="outlined"
+                                    placeholder="2"
+                                    size="small" />
+                            </TableCell>
+                            <TableCell>
+                                <TextField
+                                    variant="outlined"
+                                    placeholder="3"
+                                    size="small" />
+                            </TableCell>
+                            <TableCell>
+                                <TextField
+                                    variant="outlined"
+                                    placeholder="4"
+                                    size="small" />
+                            </TableCell>
+                        </TableRow>
+
+                    </TableBody>
+                </Table>
+            </TableContainer>
+
         </>
     );
 }

--- a/src/components/Editor/QuestionEditor.js
+++ b/src/components/Editor/QuestionEditor.js
@@ -12,6 +12,7 @@ import {
     TableBody
 } from "@mui/material";
 import styles from "./QuestionEditor.module.css";
+import { ItemTypes } from "@minoru/react-dnd-treeview";
 
 export default function QuestionEditor(props) {
 
@@ -30,12 +31,17 @@ export default function QuestionEditor(props) {
     const [questionName, setQuestionName] = useState(props.selectedNode?.text ?? "Question");
     const [defaultGrade, setDefaultGrade] = useState(props.selectedNode?.data.question.defaultGrade ?? 0.00);
     const [penalty, setPenalty] = useState(props.selectedNode?.data.question.penalty ?? 0.00);
+    const [choices, setChoices] = useState(props.selectedNode?.data.question.choicesFull ?? [{
+        text: "",
+        feedback: "",
+        value: 0
+    }]);
 
     useEffect(() => {
         setQuestionName(props.selectedNode?.text);
         setDefaultGrade(props.selectedNode?.data.question.default_grade);
         setPenalty(props.selectedNode?.data.question.penalty);
-
+        setChoices(props.selectedNode?.data.question.choicesFull);
     }, [props.selectedNode]);
 
     const questionType = () => {
@@ -154,43 +160,73 @@ export default function QuestionEditor(props) {
                     <TableHead>
                         <TableRow>
                             <TableCell width="10%">#</TableCell>
-                            <TableCell width="40%">Choices</TableCell>
-                            <TableCell width="40%">Feedback</TableCell>
-                            <TableCell width="10%">Value</TableCell>
+                            <TableCell width="30%">Choices</TableCell>
+                            <TableCell width="30%">Feedback</TableCell>
+                            <TableCell width="20%">Value</TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        <TableRow>
-                            <TableCell>
-                                <TextField
-                                    variant="outlined"
-                                    placeholder="1"
-                                    size="small" />
-                            </TableCell>
-                            <TableCell>
-                                <TextField
-                                    variant="outlined"
-                                    placeholder="2"
-                                    size="small" />
-                            </TableCell>
-                            <TableCell>
-                                <TextField
-                                    variant="outlined"
-                                    placeholder="3"
-                                    size="small" />
-                            </TableCell>
-                            <TableCell>
-                                <TextField
-                                    variant="outlined"
-                                    placeholder="4"
-                                    size="small" />
-                            </TableCell>
-                        </TableRow>
-
+                        {choices && choices.map((row, i) => (
+                            <TableRow key={i}>
+                                <TableCell>
+                                    {i + 1}
+                                </TableCell>
+                                <TableCell>
+                                    <TextField
+                                        type="text"
+                                        id="choiceText"
+                                        name="choiceText"
+                                        value={row.text}
+                                        size="small"
+                                        onChange={(e) => {
+                                            setChoices((prevChoices) => {
+                                                prevChoices[i].text = e.target.value;
+                                                return prevChoices;
+                                            });
+                                            props.onChoiceChange(e, i);
+                                        }}
+                                        />
+                                </TableCell>
+                                <TableCell>
+                                    <TextField
+                                        type="text"
+                                        id="choiceFeedback"
+                                        name="choiceFeedback"
+                                        value={row.feedback}
+                                        size="small"
+                                        onChange={(e) => {
+                                            setChoices((prevChoices) => {
+                                                prevChoices[i].feedback = e.target.value;
+                                                return prevChoices;
+                                            });
+                                            props.onChoiceChange(e, i);
+                                        }} />
+                                </TableCell>
+                                <TableCell>
+                                    <TextField
+                                        type="number"
+                                        id="choiceValue"
+                                        name="choiceValue"
+                                        value={row.value}
+                                        size="small" 
+                                        inputProps={{
+                                            min: 0,
+                                            max: 100,
+                                            step: "1"
+                                        }}
+                                        onChange={(e) => {
+                                            setChoices((prevChoices) => {
+                                                prevChoices[i].value = e.target.value;
+                                                return prevChoices;
+                                            });
+                                            props.onChoiceChange(e, i);
+                                        }}/>
+                                </TableCell>
+                            </TableRow>
+                        ))}
                     </TableBody>
                 </Table>
             </TableContainer>
-
         </>
     );
 }

--- a/src/components/QuestionBankSection/QBTree.js
+++ b/src/components/QuestionBankSection/QBTree.js
@@ -41,6 +41,46 @@ const QBTree = (props) => {
                     case "penalty":
                         newNode.data.question.penalty = e.target.value;
                         break;
+                    default:
+                        console.log("Event for choices:")
+                        console.log(e);
+
+                }
+                return newNode;
+            }
+            return node;
+        });
+        setTreeData(newTree);
+    }
+
+    const handleChoiceChange = (e, index) => {
+        const newTree = treeData.map((node) => {
+
+            if (node.id === selectedNode.id) {
+                const newNode = copyNode(node);
+                switch (e.target.name) {
+                    case "choiceText":
+                        newNode.data.question.choicesFull[index].text = e.target.value;
+                        console.log("new choice text for index: " + index);
+                        console.log(e.target.value);
+                        break;
+
+                    case "choiceFeedback":
+                        newNode.data.question.choicesFull[index].feedback = e.target.value;
+                        console.log("new choice feedback for index: " + index);
+                        console.log(e.target.value);
+                        break;
+
+                    case "choiceValue":
+                        newNode.data.question.choicesFull[index].value = e.target.value;
+                        console.log("new choice value for index: " + index);
+                        console.log(e.target.value);
+                        break;
+
+                    default:
+                        console.log("Event for choices:")
+                        console.log(e);
+
                 }
                 return newNode;
             }
@@ -171,7 +211,8 @@ const QBTree = (props) => {
                         {selectedNode && <QuestionEditor
                             selectedNode={selectedNode}
                             onFieldChange={handleFieldChange}
-                            onTextChange={handleQuestionTextChange} />}
+                            onTextChange={handleQuestionTextChange}
+                            onChoiceChange={handleChoiceChange} />}
                     </Grid>
                 </Grid>
             </ThemeProvider>

--- a/src/components/QuestionBankSection/UtilityFunctions/defaultQuestion.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/defaultQuestion.js
@@ -5,6 +5,7 @@ export const defaultQuestion = {
     name: "Default question",
     question_text: "This is your question text",
     tags: [],
+    choicesFull: [],
     choices: [],
     feedback: [],
     value: [],

--- a/src/components/QuestionBankSection/UtilityFunctions/loadXMLFile.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/loadXMLFile.js
@@ -64,6 +64,9 @@ export function loadXMLFile(questionbank, myFile) {
                 break;
             }
             case "truefalse": {
+                //TODO: later clean this up by keeping only choicesFull and removing choices, feedback, and value arrays
+                //TODO: also clean this up by using the optional chaining ?. operator instead of these if/else blocks
+
                 console.log("question.type is 'truefalse'");
                 question.name = xmlQList[i].getElementsByTagName("text")[0].firstChild.nodeValue;
                 question.question_text = xmlQList[i]
@@ -93,7 +96,13 @@ export function loadXMLFile(questionbank, myFile) {
 
                 let choices = xmlQList[i].getElementsByTagName("answer");
 
+                
                 for (let choice_nr = 0; choice_nr < choices.length; choice_nr++) {
+
+                    let choicesObject = {"text": "",
+                                      "feedback": "",
+                                      "value": 0,
+                                    }
                     if (
                         choices[choice_nr].getElementsByTagName("text")[0] &&
                         choices[choice_nr].getElementsByTagName("text")[0].childNodes[0]
@@ -103,14 +112,17 @@ export function loadXMLFile(questionbank, myFile) {
                             continue;
                         } else {
                             question.choices.push(
-                                choices[choice_nr].getElementsByTagName("text")[0].childNodes[0].nodeValue,
+                                choices[choice_nr].getElementsByTagName("text")[0].childNodes[0].nodeValue
                             );
+                            choicesObject.text = choices[choice_nr].getElementsByTagName("text")[0].childNodes[0].nodeValue;
                         }
 
                     if (choices[choice_nr].getAttribute("fraction")) {
                         question.value.push(choices[choice_nr].getAttribute("fraction"));
+                        choicesObject.value = choices[choice_nr].getAttribute("fraction")
                     } else {
                         question.value.push(0);
+                        choicesObject.text = 0;
                     }
 
                     if (
@@ -118,9 +130,12 @@ export function loadXMLFile(questionbank, myFile) {
                         choices[choice_nr].getElementsByTagName("feedback")[0].childNodes[0]
                     ) {
                         question.feedback.push(
-                            choices[choice_nr].getElementsByTagName("feedback")[0].childNodes[0].nodeValue,
+                            choices[choice_nr].getElementsByTagName("feedback")[0].childNodes[0].nodeValue
                         );
+                        choicesObject.feedback = choices[choice_nr].getElementsByTagName("feedback")[0].childNodes[0].nodeValue;
                     }
+                    question.choicesFull.push(choicesObject);
+                    console.log("Choices are: " + choicesObject);
                 }
                 questionbank.push(question); //store the imported question in the database
                 break;


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/jira/software/projects/QM/boards/34?selectedIssue=QM-46

## Context:
Allow the ability to view and edit true/false questions 
## Changes
- use TableContainer and TextField from Material UI to display and edit True/false choices (including choice text, feedback, and value).
- changed values are stored in the treenode and displayed to the user

## Before and After UI (Required for UI-impacting PRs)
Before: 
![image](https://user-images.githubusercontent.com/57333167/171230256-1418ae4e-3f89-46c1-9bdf-f0e7c48b390f.png)
After:
![image](https://user-images.githubusercontent.com/57333167/171230340-0c269266-6074-4644-a301-bd8212b209f6.png)

If this is a new UI feature, include screenshots to show reviewers what it looks like. 
## Dev notes (Optional)
- Specific technical changes that should be noted
## Linked pull requests (Optional)
- pull request link
