### PR TITLE
(feat)QM-41: export all questions to moodle xml format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-icons": "^4.3.1",
         "react-scripts": "^4.0.0",
         "react-xml-parser": "^1.1.8",
+        "reactjs-popup": "^2.0.5",
         "sass": "^1.50.1",
         "tinymce": "^6.0.2",
         "web-vitals": "^2.1.4"
@@ -17740,6 +17741,18 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-xml-parser/-/react-xml-parser-1.1.8.tgz",
       "integrity": "sha512-yX9k9LNCRzzNnFWoyo9cWEjtor6n6VD0Uh7z1ww5rIP6h5vdhJKEmowsm9RumEJMRdr7akcT4mMBScpsz573qQ=="
+    },
+    "node_modules/reactjs-popup": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.5.tgz",
+      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -36572,6 +36585,12 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-xml-parser/-/react-xml-parser-1.1.8.tgz",
       "integrity": "sha512-yX9k9LNCRzzNnFWoyo9cWEjtor6n6VD0Uh7z1ww5rIP6h5vdhJKEmowsm9RumEJMRdr7akcT4mMBScpsz573qQ=="
+    },
+    "reactjs-popup": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.5.tgz",
+      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==",
+      "requires": {}
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-icons": "^4.3.1",
     "react-scripts": "^4.0.0",
     "react-xml-parser": "^1.1.8",
+    "reactjs-popup": "^2.0.5",
     "sass": "^1.50.1",
     "tinymce": "^6.0.2",
     "web-vitals": "^2.1.4"

--- a/src/components/Editor/QuestionEditor.js
+++ b/src/components/Editor/QuestionEditor.js
@@ -41,7 +41,7 @@ const useStyles = makeStyles({
 export default function QuestionEditor(props) {
 
     const defaultChoice = {
-        text: "",
+        text: '<p dir="ltr" style="text-align: left;">  </p>',
         feedback: "",
         value: 0
     };

--- a/src/components/ExportAllMoodleButton.js
+++ b/src/components/ExportAllMoodleButton.js
@@ -3,7 +3,7 @@ import { Button, Tooltip } from "@mui/material";
 
 import DownloadIcon from '@mui/icons-material/Download';
 import PopUpFileName from './PopUpFileName';
-import {exportXMLFile } from "./QuestionBankSection/UtilityFunctions/exportXMLFile.js";
+import { exportXMLFile } from "./QuestionBankSection/UtilityFunctions/exportXMLFile.js";
 
 export default function ExportAllMoodleButton(props) {
 
@@ -12,7 +12,7 @@ export default function ExportAllMoodleButton(props) {
     const [xmlfilename, setXmlFileName] = useState("");
 
     const handleBtnClick = (e) => {
-        setShowPopup(true);       
+        setShowPopup(true);
     };
 
     useEffect(() => {
@@ -32,13 +32,17 @@ export default function ExportAllMoodleButton(props) {
                         borderColor: 'black'
                     }}
                     onClick={handleBtnClick}
-                    >
+                >
                     <DownloadIcon />
                 </Button>
-                
+
             </Tooltip>
-            <PopUpFileName show={showPopup} onClose={setShowPopup} onClick={setXmlFileName}/> 
-                   </div>
+            <PopUpFileName
+                show={showPopup}
+                onClose={setShowPopup}
+                onClick={setXmlFileName}
+                defaultFileName={props.uploadedXMLFileName} />
+        </div>
     );
 
 }

--- a/src/components/ExportAllMoodleButton.js
+++ b/src/components/ExportAllMoodleButton.js
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import { Button, Tooltip } from "@mui/material";
+
+import DownloadIcon from '@mui/icons-material/Download';
+import PopUpFileName from './PopUpFileName';
+import {exportXMLFile } from "./QuestionBankSection/UtilityFunctions/exportXMLFile.js";
+
+export default function ExportAllMoodleButton(props) {
+
+    //modal state
+    const [showPopup, setShowPopup] = useState(false);
+    const [xmlfilename, setXmlFileName] = useState("");
+
+    const handleBtnClick = (e) => {
+        setShowPopup(true);       
+    };
+
+    useEffect(() => {
+        if (xmlfilename != "")
+            exportXMLFile(xmlfilename, props.treeData);
+    }, [xmlfilename]);
+
+
+    return (
+        <div>
+            <Tooltip title={"Export All Questions as Moodle XML"} placement="top" arrow>
+                <Button variant="outlined" size="small" component="label" aria-label="Export All Questions"
+                    style={{
+                        width: "10px",
+                        height: "30px",
+                        color: 'black',
+                        borderColor: 'black'
+                    }}
+                    onClick={handleBtnClick}
+                    >
+                    <DownloadIcon />
+                </Button>
+                
+            </Tooltip>
+            <PopUpFileName show={showPopup} onClose={setShowPopup} onClick={setXmlFileName}/> 
+                   </div>
+    );
+
+}

--- a/src/components/PopUpFileName.js
+++ b/src/components/PopUpFileName.js
@@ -6,9 +6,8 @@ import { Button, TextField, Stack } from '@mui/material';
 
 export default function PopUpFileName(props) {
 
-    const [name, setName] = useState("");
+    const [name, setName] = useState(props.defaultFileName);
     const [showPopup, setShowPopup] = useState(props.show);
-    //console.log("In popup. Value of show Popup is: " + showPopup);
 
     const handleChange = (event) => {
         setName(event.target.value);
@@ -29,11 +28,11 @@ export default function PopUpFileName(props) {
     useEffect(() => {
         setShowPopup(props.show);
         console.log("Value of show in Popup is: " + props.show);
-    }, [props.show]);
+        setName(props.defaultFileName)
+    }, [props.show, props.defaultFileName]);
 
     return (
         <Popup open={showPopup} onClose={() => props.onClose(false)} modal>
-           
                 <Stack spacing={2}>
                     <TextField
                         label="Enter a file name:"
@@ -49,11 +48,7 @@ export default function PopUpFileName(props) {
                         <Button variant="contained" onClick={handleCancel} type="submit">Cancel</Button>
 
                     </Stack>
-
                 </Stack>
-
         </Popup>
-
     )
-
 }

--- a/src/components/PopUpFileName.js
+++ b/src/components/PopUpFileName.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import Popup from 'reactjs-popup';
+import 'reactjs-popup/dist/index.css';
+import { Button, TextField, Stack } from '@mui/material';
+
+
+export default function PopUpFileName(props) {
+
+    const [name, setName] = useState("");
+    const [showPopup, setShowPopup] = useState(props.show);
+    //console.log("In popup. Value of show Popup is: " + showPopup);
+
+    const handleChange = (event) => {
+        setName(event.target.value);
+    }
+
+    const handleSubmit = () => {
+        props.onClick(name);
+        setShowPopup(false);
+        setName("");
+    }
+
+    
+    const handleCancel = () => {
+        setShowPopup(false);
+        setName("");
+    }
+
+    useEffect(() => {
+        setShowPopup(props.show);
+        console.log("Value of show in Popup is: " + props.show);
+    }, [props.show]);
+
+    return (
+        <Popup open={showPopup} onClose={() => props.onClose(false)} modal>
+           
+                <Stack spacing={2}>
+                    <TextField
+                        label="Enter a file name:"
+                        name="filename"
+                        type="text"
+                        size="small"
+                        sx={{ width: 300 }}
+                        value={name}
+                        onChange={handleChange}
+                    />
+                    <Stack direction="row" spacing={2} >
+                        <Button variant="contained" onClick={handleSubmit} type="submit">OK</Button>
+                        <Button variant="contained" onClick={handleCancel} type="submit">Cancel</Button>
+
+                    </Stack>
+
+                </Stack>
+
+        </Popup>
+
+    )
+
+}

--- a/src/components/PopUpFileName.module.css
+++ b/src/components/PopUpFileName.module.css
@@ -1,0 +1,33 @@
+.modal {
+    font-size: 12px;
+  }
+  .modal > .header {
+    width: 100%;
+    border-bottom: 1px solid gray;
+    font-size: 18px;
+    text-align: center;
+    padding: 5px;
+  }
+  .modal > .content {
+    width: 100%;
+    padding: 10px 5px;
+  }
+  .modal > .actions {
+    width: 100%;
+    padding: 10px 5px;
+    margin: auto;
+    text-align: center;
+  }
+  .modal > .close {
+    cursor: pointer;
+    position: absolute;
+    display: block;
+    padding: 2px 5px;
+    line-height: 20px;
+    right: -10px;
+    top: -10px;
+    font-size: 24px;
+    background: #ffffff;
+    border-radius: 18px;
+    border: 1px solid #cfcece;
+  }

--- a/src/components/QuestionBankSection/QBTree.js
+++ b/src/components/QuestionBankSection/QBTree.js
@@ -214,18 +214,31 @@ const QBTree = (props) => {
     };
 
     const getParentCategoryKey = (question, questionbank) => {
-        let parentCat = question.category.replace(question.name, "");
-        //console.log('last char is: ' + parentCat.charAt(parentCat.length - 1));
-        if (parentCat.charAt(parentCat.length - 1) === "/") {
-            //console.log("last char is a /");
-            parentCat = parentCat.slice(0, parentCat.length - 1);
+        console.log("Question category is: " + question.category);
+        let parentCat;
+        if (question.type === "category") {
+            parentCat = question.category.replace(question.name, "");
+
+            console.log('last char is: ' + parentCat.charAt(parentCat.length - 1));
+            
+            if (parentCat.charAt(parentCat.length - 1) === "/") {
+                console.log("last char is a /");
+                parentCat = parentCat.slice(0, parentCat.length - 1);
+            }
+            parentCat.trim();
+
+        } else {
+            parentCat = question.category;
         }
-        parentCat.trim();
-        // console.log("Question Name: " + question.name);
-        // console.log("Question Category: " + question.category);
-        // console.log("Parent category: " + parentCat);
+
+
         let parentKey = getDumCatKey(parentCat, questionbank);
-        // console.log('ParentKey is: ' + parentKey);
+        if (parentKey === -1) {
+            console.log("No parent key found");
+            console.log(question);
+            console.log("Parent category: " + parentCat);
+        }
+
         return parentKey;
     };
 
@@ -243,6 +256,10 @@ const QBTree = (props) => {
                     question: questionbank[i],
                 },
             };
+            // if (data.parent === -1) {
+            //     console.log(`Questionbank[${i}] is: `);
+            //     console.log(questionbank[i]);
+            // }
             myTreeData.push(data);
         }
 

--- a/src/components/QuestionBankSection/QBTree.js
+++ b/src/components/QuestionBankSection/QBTree.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { makeStyles } from '@material-ui/core/styles'
 import { Grid, Box } from "@mui/material";
 import { Tree } from "@minoru/react-dnd-treeview";
-import defaultTree from "./defaultTree.json";
+
 import { ThemeProvider, CssBaseline } from "@mui/material";
 import { StylesProvider } from "@material-ui/styles";
 import { CustomNode } from "./CustomNode";
@@ -39,7 +39,7 @@ const QBTree = (props) => {
 
     //const classes = useStyles();
 
-    const [treeData, setTreeData] = useState(defaultTree);
+    //const [treeData, setTreeData] = useState(defaultTree);
     //const handleDrop = (newTree) => setTreeData(newTree);
     const [selectedNode, setSelectedNode] = useState(null);
 
@@ -52,7 +52,7 @@ const QBTree = (props) => {
     };
 
     const handleFieldChange = (e) => {
-        const newTree = treeData.map((node) => {
+        const newTree = props.treeData.map((node) => {
 
             if (node.id === selectedNode.id) {
                 const newNode = copyNode(node);
@@ -90,11 +90,11 @@ const QBTree = (props) => {
             }
             return node;
         });
-        setTreeData(newTree);
+        props.setTreeData(newTree);
     }
 
     const handleChoiceEdit = (e, index) => {
-        const newTree = treeData.map((node) => {
+        const newTree = props.treeData.map((node) => {
 
             if (node.id === selectedNode.id) {
                 const newNode = copyNode(node);
@@ -129,11 +129,11 @@ const QBTree = (props) => {
             }
             return node;
         });
-        setTreeData(newTree);
+        props.setTreeData(newTree);
     }
 
     const handleChoiceTableModify = (action, choices) => {
-        const newTree = treeData.map((node) => {
+        const newTree = props.treeData.map((node) => {
             if (node.id === selectedNode.id) {
                 const newNode = copyNode(node);
 
@@ -168,12 +168,12 @@ const QBTree = (props) => {
             }
             return node;
         });
-        setTreeData(newTree);
+        props.setTreeData(newTree);
     }
 
 
     const handleQuestionTextChange = (value) => {
-        const newTree = treeData.map((node) => {
+        const newTree = props.treeData.map((node) => {
 
             console.log("value is: " + value);
 
@@ -186,7 +186,7 @@ const QBTree = (props) => {
             }
             return node;
         });
-        setTreeData(newTree);
+        props.setTreeData(newTree);
     }
 
     const myFile = props.file;
@@ -249,7 +249,7 @@ const QBTree = (props) => {
         console.log("Printing out myTreeData");
         console.log(myTreeData);
 
-        setTreeData([...myTreeData]);
+        props.setTreeData([...myTreeData]);
     };
 
     useEffect(() => {
@@ -283,7 +283,7 @@ const QBTree = (props) => {
                             overflowY: "auto",
                         }}>
                             <Tree
-                                tree={treeData}
+                                tree={props.treeData}
                                 rootId={-1}
                                 render={(node: NodeModel<CustomData>,
                                     { depth, isOpen, onToggle }

--- a/src/components/QuestionBankSection/QuestionBankSection.js
+++ b/src/components/QuestionBankSection/QuestionBankSection.js
@@ -7,11 +7,11 @@ import QBTree from "./QBTree";
 import { Typography } from "@mui/material";
 import defaultTree from "./defaultTree.json";
 import ExportAllMoodleButton from "../ExportAllMoodleButton";
-import PopUpFileName from '../PopUpFileName';
 
 const QuestionBankSection = (props) => {
 
     const [treeData, setTreeData] = useState(defaultTree);
+    const [uploadedXMLFileName, setUploadedXMLFileName] = useState("");
 
 
     return (
@@ -22,8 +22,8 @@ const QuestionBankSection = (props) => {
                 direction="row"
                 justifyContent="flex-start"
                 alignItems="flex-start">
-                <UploadButton setFile={props.setFile} setFileObject={props.setFileObject} />
-                <ExportAllMoodleButton treeData={treeData}/>
+                <UploadButton setFile={props.setFile} setFileObject={props.setFileObject} setUploadedXMLFileName={setUploadedXMLFileName}/>
+                <ExportAllMoodleButton treeData={treeData} uploadedXMLFileName={uploadedXMLFileName}/>
             </Stack>
             <QBTree
                 file={props.file}

--- a/src/components/QuestionBankSection/QuestionBankSection.js
+++ b/src/components/QuestionBankSection/QuestionBankSection.js
@@ -1,18 +1,36 @@
+import React, { useState } from 'react';
+import { Stack } from "@mui/material";
 import UploadButton from "../UploadButton";
 import { Fragment } from "react";
 import { AiFillBank } from "react-icons/ai";
 import QBTree from "./QBTree";
-import {Typography} from "@mui/material";
+import { Typography } from "@mui/material";
+import defaultTree from "./defaultTree.json";
+import ExportAllMoodleButton from "../ExportAllMoodleButton";
+import PopUpFileName from '../PopUpFileName';
 
 const QuestionBankSection = (props) => {
+
+    const [treeData, setTreeData] = useState(defaultTree);
+
+
     return (
         <Fragment>
-            <Typography variant="h5" style={{fontWeight: 600}}>Question Bank<AiFillBank /></Typography>
-            <UploadButton setFile={props.setFile} setFileObject={props.setFileObject} />
+            <Typography variant="h5" style={{ fontWeight: 600 }}>Question Bank<AiFillBank /></Typography>
+            <Stack
+                spacing={0.5}
+                direction="row"
+                justifyContent="flex-start"
+                alignItems="flex-start">
+                <UploadButton setFile={props.setFile} setFileObject={props.setFileObject} />
+                <ExportAllMoodleButton treeData={treeData}/>
+            </Stack>
             <QBTree
                 file={props.file}
                 selectedNode={props.selectedNode}
                 setSelectedNode={props.setSelectedNode}
+                treeData={treeData}
+                setTreeData={setTreeData}
             />
         </Fragment>
     );

--- a/src/components/QuestionBankSection/UtilityFunctions/download.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/download.js
@@ -1,0 +1,17 @@
+export function download(data, filename, type) {
+    var file = new Blob([data], {type: type});
+    if (window.navigator.msSaveOrOpenBlob) // IE10+
+        window.navigator.msSaveOrOpenBlob(file, filename);
+    else { // Others
+        var a = document.createElement("a"),
+                url = URL.createObjectURL(file);
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(function() {
+            document.body.removeChild(a);
+            window.URL.revokeObjectURL(url);  
+        }, 0); 
+    }
+}

--- a/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
@@ -1,0 +1,118 @@
+import {download} from "./download.js"
+
+export function exportXMLFile(fileName, treeData) {
+
+    if (treeData.length < 1) {
+        return;
+    }
+    console.log("TreeData is: ");
+    console.log(treeData);
+
+    console.log("first node data is: ");
+    console.log(treeData[0].data);
+
+    console.log("first question");
+    console.log(treeData[0].data.question);
+
+
+    let current_file = ""; //see if there's a way to keep the file that was open as a default.
+
+    if (fileName === "") {
+        current_file = "default.xml"
+    }
+
+    else {
+        current_file = fileName + ".xml";
+    }
+    let cat = "";
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + '<quiz>\n';
+
+    let len = treeData.length;
+    console.log("Saving " + len + " questions"); //see if there's a way to alert the user
+
+    let counter = 0;
+
+    for (let i = 0; i < len; i++) {
+        let nr = i;
+        let q = treeData[nr].data.question;
+        if (q.type == "category") continue;
+        counter++;
+        if (q.category != cat) {
+            xml += '<question type="category">\n<category>\n<text>' + q.category + '</text>\n</category>\n</question>';
+            cat = q.category;
+        }
+        xml += '<question type="' + q.type + '">\n' +
+            '<name>\n<text>' + q.name + '</text>\n</name>\n' +
+            '<questiontext format="html">\n<text><';
+        xml += '![CDATA[' + q.question_text + ']]';
+        xml += '></text>\n</questiontext>\n' +
+            '<generalfeedback format="html">\n' +
+            '<text></text>\n</generalfeedback>\n';
+
+        switch (q.type) {
+            case "truefalse": {
+                xml += '<defaultgrade>' + q.default_grade + '</defaultgrade>\n' +
+                    '<penalty>' + q.penalty + '</penalty>\n' +
+                    '<hidden> 0 </hidden>\n' +
+                    '<correctfeedback format="html"><text></text></correctfeedback>\n' +
+                    '<partiallycorrectfeedback format = "html"><text></text></partiallycorrectfeedback>\n' +
+                    '<incorrectfeedback format = "html"><text></text></incorrectfeedback>\n' +
+                    '<answer fraction = "' + q.choicesFull[0].value + '" format = "html">\n<text>true</text>\n<feedback format = "html">\n<text><![CDATA[' + q.choicesFull[0].feedback + ']]></text>\n</feedback>\n</answer>\n' +
+                    '<answer fraction = "' + q.choicesFull[1].value + '" format = "html">\n<text>false</text>\n<feedback format = "html">\n<text><![CDATA[' + q.choicesFull[1].feedback + ']]></text>\n</feedback>\n</answer>\n';
+                break;
+            }
+
+            case "multichoice": {
+                xml += '<defaultgrade>' + q.default_grade + '</defaultgrade>\n' +
+                    '<penalty>' + q.penalty + '</penalty>\n' +
+                    '<hidden> 0 </hidden>\n' +
+                    '<single>' + q.single_answer + '</single>\n' +
+                    '<shuffleanswers>' + (q.shuffle_answers ? '1' : '0') + '</shuffleanswers>\n' +
+                    '<answernumbering>' + answer_numbering[q.numbering] + '</answernumbering>\n' +
+                    '<correctfeedback format="html"><text></text></correctfeedback>\n' +
+                    '<partiallycorrectfeedback format = "html"><text></text></partiallycorrectfeedback>\n' +
+                    '<incorrectfeedback format = "html"><text></text></incorrectfeedback>\n';
+                for (var c = 0; c < q.choicesFull.length; c++) {
+                    xml += '<answer fraction = "' + q.choicesFull[c].value + '" format = "html">\n<text><![CDATA[' + q.choicesFull[c] + ']]>\n</text>\n' +
+                        '<feedback format = "html">\n<text><![CDATA[' + q.choicesFull[c].feedback + ']]></text>\n' +
+                        '</feedback>\n</answer>\n';
+                }
+                break;
+            }
+
+            case "shortanswer": {
+                xml += '<defaultgrade>' + q.default_grade + '</defaultgrade>\n' +
+                    '<penalty>' + q.penalty + '</penalty>\n' +
+                    '<hidden> 0 </hidden>\n'; '<usecase>' + q.case_sensitive + '</usecase>\n' +
+                        '<correctfeedback format="html"><text></text></correctfeedback>\n' +
+                        '<partiallycorrectfeedback format = "html"><text></text></partiallycorrectfeedback>\n' +
+                        '<incorrectfeedback format = "html"><text></text></incorrectfeedback>\n';
+                for (var c = 0; c < q.choicesFull.length; c++) {
+                    xml += '<answer fraction = "' + q.choicesFull[c].value + '" format = "html">\n<text><![CDATA[' + q.choicesFull[c] + ']]>\n</text>\n' +
+                        '<feedback format = "html">\n<text ><![CDATA[' + q.choicesFull[c].feedback + ']]></text>\n' +
+                        '</feedback>\n</answer>\n';
+                }
+                break;
+            }
+
+            case "essay": {
+                xml += '<defaultgrade>' + q.default_grade + '</defaultgrade>\n' +
+                    '<penalty>' + q.penalty + '</penalty>\n' +
+                    '<hidden> 0 </hidden>\n<correctfeedback format="html"><text></text></correctfeedback>\n' +
+                    '<partiallycorrectfeedback format = "html"><text></text></partiallycorrectfeedback>\n' +
+                    '<incorrectfeedback format = "html"><text></text></incorrectfeedback>\n';
+                break;
+            }
+
+            case "description": {
+                break;
+
+            }
+        }
+    }
+
+    xml += '</quiz>';
+    download(xml, current_file, "text");
+    //alert_box("Downloaded file contains " + counter + " questions");
+
+}

--- a/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
@@ -6,15 +6,6 @@ export function exportXMLFile(fileName, treeData) {
     if (treeData.length < 1) {
         return;
     }
-    console.log("TreeData is: ");
-    console.log(treeData);
-
-    console.log("first node data is: ");
-    console.log(treeData[0].data);
-
-    console.log("first question");
-    console.log(treeData[0].data.question);
-
 
     let current_file = ""; //see if there's a way to keep the file that was open as a default.
 

--- a/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
@@ -7,15 +7,21 @@ export function exportXMLFile(fileName, treeData) {
         return;
     }
 
-    let current_file = ""; //see if there's a way to keep the file that was open as a default.
+    let current_file = ""; 
 
     if (fileName === "") {
         current_file = "default.xml"
     }
 
     else {
-        current_file = fileName + ".xml";
+        ext = (fileName.lastIndexOf(".") - 1 >>> 0) + 2;
+        if (ext === "xml") {
+            current_file = fileName
+        } else {
+            current_file = fileName + ".xml";
+        }
     }
+
     let cat = "";
     let xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + '<quiz>\n';
 
@@ -33,7 +39,7 @@ export function exportXMLFile(fileName, treeData) {
             xml += '<question type="category">\n<category>\n<text>' + q.category + '</text>\n</category>\n</question>';
             cat = q.category;
         }
-        
+
         xml += '<question type="' + q.type + '">\n' +
             '<name>\n<text>' + q.name + '</text>\n</name>\n' +
             '<questiontext format="html">\n<text><';

--- a/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
@@ -1,4 +1,4 @@
-import {download} from "./download.js";
+import { download } from "./download.js";
 import * as Constants from "../../../constants/questionBankConstants.js";
 
 export function exportXMLFile(fileName, treeData) {
@@ -22,17 +22,18 @@ export function exportXMLFile(fileName, treeData) {
     let len = treeData.length;
     console.log("Saving " + len + " questions"); //see if there's a way to alert the user
 
-    let counter = 0;
-
     for (let i = 0; i < len; i++) {
         let nr = i;
         let q = treeData[nr].data.question;
-        if (q.type == "category") continue;
-        counter++;
+
+        if (q.type == "category")
+            continue;
+
         if (q.category != cat) {
             xml += '<question type="category">\n<category>\n<text>' + q.category + '</text>\n</category>\n</question>';
             cat = q.category;
         }
+        
         xml += '<question type="' + q.type + '">\n' +
             '<name>\n<text>' + q.name + '</text>\n</name>\n' +
             '<questiontext format="html">\n<text><';
@@ -105,20 +106,17 @@ export function exportXMLFile(fileName, treeData) {
             }
         }
 
-        if (q.tags[0] != "")
-			{
-			xml+="<tags>\n";
-			for (var tagnr=0;tagnr<q.tags.length;tagnr++)
-				{
-				xml+="<tag><text>"+q.tags[tagnr]+"</text></tag>\n";
-				}
-			xml+="</tags>\n";
-			}
-		xml+='</question>\n';
+        if (q.tags[0] != "") {
+            xml += "<tags>\n";
+            for (var tagnr = 0; tagnr < q.tags.length; tagnr++) {
+                xml += "<tag><text>" + q.tags[tagnr] + "</text></tag>\n";
+            }
+            xml += "</tags>\n";
+        }
+        xml += '</question>\n';
     }
 
     xml += '</quiz>';
     download(xml, current_file, "text");
-    //alert_box("Downloaded file contains " + counter + " questions");
 
 }

--- a/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
@@ -1,4 +1,5 @@
-import {download} from "./download.js"
+import {download} from "./download.js";
+import * as Constants from "../../../constants/questionBankConstants.js";
 
 export function exportXMLFile(fileName, treeData) {
 
@@ -57,9 +58,10 @@ export function exportXMLFile(fileName, treeData) {
                     '<correctfeedback format="html"><text></text></correctfeedback>\n' +
                     '<partiallycorrectfeedback format = "html"><text></text></partiallycorrectfeedback>\n' +
                     '<incorrectfeedback format = "html"><text></text></incorrectfeedback>\n' +
-                    '<answer fraction = "' + q.choicesFull[0].value + '" format = "html">\n<text>true</text>\n<feedback format = "html">\n<text><![CDATA[' + q.choicesFull[0].feedback + ']]></text>\n</feedback>\n</answer>\n' +
-                    '<answer fraction = "' + q.choicesFull[1].value + '" format = "html">\n<text>false</text>\n<feedback format = "html">\n<text><![CDATA[' + q.choicesFull[1].feedback + ']]></text>\n</feedback>\n</answer>\n';
+                    '<answer fraction = "' + q.choicesFull[0].value + '" format = "html">\n<text><![CDATA[' + q.choicesFull[0].text + ']]>\n</text>\n<feedback format = "html">\n<text><![CDATA[' + q.choicesFull[0].feedback + ']]></text>\n</feedback>\n</answer>\n' +
+                    '<answer fraction = "' + q.choicesFull[1].value + '" format = "html">\n<text><![CDATA[' + q.choicesFull[1].text + ']]>\n</text>\n<feedback format = "html">\n<text><![CDATA[' + q.choicesFull[1].feedback + ']]></text>\n</feedback>\n</answer>\n';
                 break;
+                //check if true / false need to be hard-coded like in V1.0. 
             }
 
             case "multichoice": {
@@ -68,12 +70,14 @@ export function exportXMLFile(fileName, treeData) {
                     '<hidden> 0 </hidden>\n' +
                     '<single>' + q.single_answer + '</single>\n' +
                     '<shuffleanswers>' + (q.shuffle_answers ? '1' : '0') + '</shuffleanswers>\n' +
-                    '<answernumbering>' + answer_numbering[q.numbering] + '</answernumbering>\n' +
+                    '<answernumbering>' + Constants.answer_numbering[q.numbering] + '</answernumbering>\n' +
                     '<correctfeedback format="html"><text></text></correctfeedback>\n' +
                     '<partiallycorrectfeedback format = "html"><text></text></partiallycorrectfeedback>\n' +
                     '<incorrectfeedback format = "html"><text></text></incorrectfeedback>\n';
                 for (var c = 0; c < q.choicesFull.length; c++) {
-                    xml += '<answer fraction = "' + q.choicesFull[c].value + '" format = "html">\n<text><![CDATA[' + q.choicesFull[c] + ']]>\n</text>\n' +
+                    console.log("Content of ChoicesFull at position" + c);
+                    console.log(q.choicesFull[c]);
+                    xml += '<answer fraction = "' + q.choicesFull[c].value + '" format = "html">\n<text><![CDATA[' + q.choicesFull[c].text + ']]>\n</text>\n' +
                         '<feedback format = "html">\n<text><![CDATA[' + q.choicesFull[c].feedback + ']]></text>\n' +
                         '</feedback>\n</answer>\n';
                 }
@@ -88,7 +92,7 @@ export function exportXMLFile(fileName, treeData) {
                         '<partiallycorrectfeedback format = "html"><text></text></partiallycorrectfeedback>\n' +
                         '<incorrectfeedback format = "html"><text></text></incorrectfeedback>\n';
                 for (var c = 0; c < q.choicesFull.length; c++) {
-                    xml += '<answer fraction = "' + q.choicesFull[c].value + '" format = "html">\n<text><![CDATA[' + q.choicesFull[c] + ']]>\n</text>\n' +
+                    xml += '<answer fraction = "' + q.choicesFull[c].value + '" format = "html">\n<text><![CDATA[' + q.choicesFull[c].text + ']]>\n</text>\n' +
                         '<feedback format = "html">\n<text ><![CDATA[' + q.choicesFull[c].feedback + ']]></text>\n' +
                         '</feedback>\n</answer>\n';
                 }
@@ -109,6 +113,17 @@ export function exportXMLFile(fileName, treeData) {
 
             }
         }
+
+        if (q.tags[0] != "")
+			{
+			xml+="<tags>\n";
+			for (var tagnr=0;tagnr<q.tags.length;tagnr++)
+				{
+				xml+="<tag><text>"+q.tags[tagnr]+"</text></tag>\n";
+				}
+			xml+="</tags>\n";
+			}
+		xml+='</question>\n';
     }
 
     xml += '</quiz>';

--- a/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
+++ b/src/components/QuestionBankSection/UtilityFunctions/exportXMLFile.js
@@ -14,7 +14,7 @@ export function exportXMLFile(fileName, treeData) {
     }
 
     else {
-        ext = (fileName.lastIndexOf(".") - 1 >>> 0) + 2;
+        let ext = (fileName.lastIndexOf(".") - 1 >>> 0) + 2;
         if (ext === "xml") {
             current_file = fileName
         } else {

--- a/src/components/UploadButton.js
+++ b/src/components/UploadButton.js
@@ -3,13 +3,12 @@ import { AiOutlineUpload, AiFillFolderOpen } from "react-icons/ai";
 
 export default function UploadButton(props) {
     function changeHandler(event) {
-        //event.preventDefault();
         const myFileObject = event.target.files[0];
         props.setFileObject(event.target.files[0]);
+        props.setUploadedXMLFileName(event.target.files[0].name);
         const reader = new FileReader();
 
         reader.onload = function (evt) {
-            //evt.preventDefault();
             props.setFile(evt.target.result);
         };
 

--- a/src/components/UploadButton.js
+++ b/src/components/UploadButton.js
@@ -17,14 +17,11 @@ export default function UploadButton(props) {
     }
 
     return (
-        <Box mt={1}>
             <Tooltip title={"Upload a file"} placement="top" arrow>
                 <Button variant="outlined" size="small" component="label" aria-label="upload a file"
-                    style={{
-                        maxWidth: "50px",
-                        maxHeight: "50px",
-                        minWidth: "30px",
-                        minHeight: "30px",
+                style={{
+                        width: "10px",
+                        height: "30px",
                         color: 'black',
                         borderColor: 'black'
                     }}>
@@ -32,6 +29,5 @@ export default function UploadButton(props) {
                     <input type="file" onChange={changeHandler} hidden />
                 </Button>
             </Tooltip>
-        </Box>
     );
 }


### PR DESCRIPTION
JIRA: link to jira ticket
https://champlainsaintlambert.atlassian.net/browse/QM-41

## Context:
Export all currently supported questions types (i.e. basic types) to MoodleXML format. 

## Changes
- added an export all button
- when button is clicked, a popup is presented to the user to get the desired filename. The filename of the previously imported file is set as a default filename
- conversion from our treedata to xml format was added
- resultant file was imported into moodle to test that the format is correct and that the changes made to the file are present.

## Before and After UI (Required for UI-impacting PRs)
Before:
![image](https://user-images.githubusercontent.com/57333167/172929809-8d761656-4e89-45c9-98dc-fc3b7a38ea72.png)
After:
Export All icon
![image](https://user-images.githubusercontent.com/57333167/172930093-3b091f86-4f64-44b2-b93e-d1a6f8659697.png)
FileName Popup
![image](https://user-images.githubusercontent.com/57333167/172930310-68f06e78-62df-453c-b767-6b16244a4255.png)
After export
![image](https://user-images.githubusercontent.com/57333167/172930664-c5960a34-d4e1-44c6-8fbb-8f6062da1d1b.png)

## Dev notes (Optional)
- Popup still needs some styling work.
- lifted treeData state to QuestionBankSection.js from QBTree.js so that the export functionality has access to it.

## Linked pull requests (Optional)
- pull request link
